### PR TITLE
fix warnings

### DIFF
--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::{prelude::*, throw_str};
 pub struct AES {}
 
 #[wasm_bindgen]
+#[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy)]
 pub enum AESAlgorithms {
     AES128_CBC,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 #[macro_use]
 extern crate num_derive;
 


### PR DESCRIPTION
- allow non_camel_case_types for AESAlgorithms enum.
- globally allow dead_code & unused_imports for non-wasm32 target arch.
