### PR TITLE
OP_FALSE, 00 and 0 as OP_0 and OP_TRUE, 01 and 1 as OP_1

### DIFF
--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -174,7 +174,11 @@ impl Script {
         // Number OP_CODES
         match code {
             "0" => return Ok(ScriptBit::OpCode(OpCodes::OP_0)),
+            "00" => return Ok(ScriptBit::OpCode(OpCodes::OP_0)),
+            "OP_FALSE" => return Ok(ScriptBit::OpCode(OpCodes::OP_0)),
             "1" => return Ok(ScriptBit::OpCode(OpCodes::OP_1)),
+            "01" => return Ok(ScriptBit::OpCode(OpCodes::OP_1)),
+            "OP_TRUE" => return Ok(ScriptBit::OpCode(OpCodes::OP_1)),
             "2" => return Ok(ScriptBit::OpCode(OpCodes::OP_2)),
             "3" => return Ok(ScriptBit::OpCode(OpCodes::OP_3)),
             "4" => return Ok(ScriptBit::OpCode(OpCodes::OP_4)),

--- a/src/script/script_template.rs
+++ b/src/script/script_template.rs
@@ -1,4 +1,4 @@
-use crate::OpCodes::OP_0;
+use crate::OpCodes::{OP_0,OP_1};
 use std::str::FromStr;
 
 use crate::{BSVErrors, OpCodes, PublicKey, Script, ScriptBit, Signature, VarInt};
@@ -64,6 +64,8 @@ pub struct ScriptTemplate(Vec<MatchToken>);
 
 impl ScriptTemplate {
     fn map_string_to_match_token(code: &str) -> Result<MatchToken, ScriptTemplateErrors> {
+        let code = code.trim();
+
         // Number OP_CODES
         if code.len() < 3 {
             if let Ok(num_code) = u8::from_str(code) {
@@ -73,6 +75,12 @@ impl ScriptTemplate {
                     _ => (),
                 }
             }
+        }
+
+        match code {
+            "OP_FALSE" => return Ok(MatchToken::OpCode(OP_0)),
+            "OP_TRUE" => return Ok(MatchToken::OpCode(OP_1)),
+            _ => (),
         }
 
         // Standard OP_CODES

--- a/tests/script_template.rs
+++ b/tests/script_template.rs
@@ -15,6 +15,21 @@ mod script_template_tests {
     }
 
     #[test]
+    fn op_false_op_zero_and_zero_script_does_match_template() {
+        let script = Script::from_asm_string("0 00 OP_0 OP_FALSE").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("OP_FALSE OP_FALSE OP_FALSE 0").unwrap();
+        println!("f {:?} {:?}", script, script_template);
+        assert_eq!(script.is_match(&script_template), true);
+    }
+
+    #[test]
+    fn op_true_op_one_and_one_script_does_match_template() {
+        let script = Script::from_asm_string("1 01 OP_1 OP_TRUE").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("OP_TRUE OP_TRUE OP_TRUE 1").unwrap();
+        assert_eq!(script.is_match(&script_template), true);
+    }
+
+    #[test]
     fn exact_script_template_matches_script_without_extracting_data() {
         let script =
             Script::from_asm_string("d26f2b12ee0a5923dab7314e533917f2ab5b50da5ce302d3d60941f0ee8000a2 21e8 OP_SIZE OP_4 OP_PICK OP_SHA256 OP_SWAP OP_SPLIT OP_DROP OP_EQUALVERIFY OP_DROP OP_CHECKSIG")


### PR DESCRIPTION
I was having problems trying to match script template that was using "00" and "OP_FALSE" as OP_0. This patch makes it work.