### PR TITLE
solve script matches with templates using op_if

### DIFF
--- a/src/script/script_template.rs
+++ b/src/script/script_template.rs
@@ -166,13 +166,16 @@ impl ScriptTemplate {
  */
 impl Script {
     pub fn match_impl(&self, script_template: &ScriptTemplate) -> Result<Vec<(MatchDataTypes, Vec<u8>)>, ScriptTemplateErrors> {
-        if self.0.len() != script_template.0.len() {
-            return Err(ScriptTemplateErrors::LengthsDiffer);
-        }
-
         let mut matches = vec![];
+        let mut script_iter = self.iter();
+        let mut template_iter = script_template.0.iter().enumerate();
 
-        for (i, (template, script)) in script_template.0.iter().zip(self.0.iter()).enumerate() {
+        loop {
+            let (i, template, script) = match (template_iter.next(), script_iter.next()) {
+                (Some((i,t)),Some(s)) => (i,t,s),
+                (None,None) => break,
+                _ => return Err(ScriptTemplateErrors::LengthsDiffer)
+            };
             let is_match = match (template, script) {
                 (MatchToken::OpCode(tmpl_code), ScriptBit::OpCode(op_code)) => Ok(tmpl_code == op_code),
                 (MatchToken::Push(tmpl_data), ScriptBit::Push(data)) => Ok(*tmpl_data == *data),

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -519,4 +519,14 @@ mod script_tests {
 
         assert_eq!(&script.to_asm_string(), "OP_RETURN 0 01 0 00 00 00 00 00 00 00 00 00000000")
     }
+
+    #[test]
+    fn byte_serialization_with_if() {
+        let asm = "OP_1 OP_IF OP_1 OP_ELSE OP_0 OP_ENDIF OP_DROP";
+        let script = Script::from_asm_string(&asm).unwrap();
+        let script_bytes = script.to_bytes();
+        let script2 = Script::from_bytes(&script_bytes).unwrap();
+        let script2_asm = script2.to_extended_asm_string();
+        assert_eq!(asm, script2_asm);
+    }
 }

--- a/tests/script_template.rs
+++ b/tests/script_template.rs
@@ -15,6 +15,15 @@ mod script_template_tests {
     }
 
     #[test]
+    fn op_if_does_match_template() {
+        let asm = "OP_1 OP_IF OP_1 OP_ELSE OP_0 OP_ENDIF OP_DROP";
+        let script = Script::from_asm_string(&asm).unwrap();
+        let script_template = ScriptTemplate::from_asm_string(&asm).unwrap();
+        println!("ref {:?} {:?}", script, script_template);
+        assert_eq!(script.is_match(&script_template), true);
+    }
+
+    #[test]
     fn exact_script_template_matches_script_without_extracting_data() {
         let script =
             Script::from_asm_string("d26f2b12ee0a5923dab7314e533917f2ab5b50da5ce302d3d60941f0ee8000a2 21e8 OP_SIZE OP_4 OP_PICK OP_SHA256 OP_SWAP OP_SPLIT OP_DROP OP_EQUALVERIFY OP_DROP OP_CHECKSIG")


### PR DESCRIPTION
Templates that had OP_IF were not working. This patch creates a iterator on script that expands OP_IF for matching and for ASM and BYTE serializations.