### PR TITLE
Make OP_FALSE and 0 use OP_0 and OP_TRUE use OP_1

### DIFF
--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -173,8 +173,11 @@ impl Script {
         let code = code.trim();
         // Number OP_CODES
         match code {
+            "-1" => return Ok(ScriptBit::OpCode(OpCodes::OP_1NEGATE)),
             "0" => return Ok(ScriptBit::OpCode(OpCodes::OP_0)),
+            "OP_FALSE" => return Ok(ScriptBit::OpCode(OpCodes::OP_0)),
             "1" => return Ok(ScriptBit::OpCode(OpCodes::OP_1)),
+            "OP_TRUE" => return Ok(ScriptBit::OpCode(OpCodes::OP_1)),
             "2" => return Ok(ScriptBit::OpCode(OpCodes::OP_2)),
             "3" => return Ok(ScriptBit::OpCode(OpCodes::OP_3)),
             "4" => return Ok(ScriptBit::OpCode(OpCodes::OP_4)),

--- a/src/script/script_template.rs
+++ b/src/script/script_template.rs
@@ -1,9 +1,7 @@
-use crate::OpCodes::OP_0;
 use std::str::FromStr;
 
 use crate::{BSVErrors, OpCodes, PublicKey, Script, ScriptBit, Signature, VarInt};
 use hex::FromHexError;
-use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use thiserror::Error;
@@ -64,15 +62,28 @@ pub struct ScriptTemplate(Vec<MatchToken>);
 
 impl ScriptTemplate {
     fn map_string_to_match_token(code: &str) -> Result<MatchToken, ScriptTemplateErrors> {
-        // Number OP_CODES
-        if code.len() < 3 {
-            if let Ok(num_code) = u8::from_str(code) {
-                match num_code {
-                    0 => return Ok(MatchToken::OpCode(OP_0)),
-                    v @ 1..=16 => return Ok(MatchToken::OpCode(OpCodes::from_u8(v + 80).unwrap())),
-                    _ => (),
-                }
-            }
+        match code {
+            "-1" => return Ok(MatchToken::OpCode(OpCodes::OP_1NEGATE)),
+            "0" => return Ok(MatchToken::OpCode(OpCodes::OP_0)),
+            "OP_FALSE" => return Ok(MatchToken::OpCode(OpCodes::OP_0)),
+            "1" => return Ok(MatchToken::OpCode(OpCodes::OP_1)),
+            "OP_TRUE" => return Ok(MatchToken::OpCode(OpCodes::OP_1)),
+            "2" => return Ok(MatchToken::OpCode(OpCodes::OP_2)),
+            "3" => return Ok(MatchToken::OpCode(OpCodes::OP_3)),
+            "4" => return Ok(MatchToken::OpCode(OpCodes::OP_4)),
+            "5" => return Ok(MatchToken::OpCode(OpCodes::OP_5)),
+            "6" => return Ok(MatchToken::OpCode(OpCodes::OP_6)),
+            "7" => return Ok(MatchToken::OpCode(OpCodes::OP_7)),
+            "8" => return Ok(MatchToken::OpCode(OpCodes::OP_8)),
+            "9" => return Ok(MatchToken::OpCode(OpCodes::OP_9)),
+            "10" => return Ok(MatchToken::OpCode(OpCodes::OP_10)),
+            "11" => return Ok(MatchToken::OpCode(OpCodes::OP_11)),
+            "12" => return Ok(MatchToken::OpCode(OpCodes::OP_12)),
+            "13" => return Ok(MatchToken::OpCode(OpCodes::OP_13)),
+            "14" => return Ok(MatchToken::OpCode(OpCodes::OP_14)),
+            "15" => return Ok(MatchToken::OpCode(OpCodes::OP_15)),
+            "16" => return Ok(MatchToken::OpCode(OpCodes::OP_16)),
+            _ => (),
         }
 
         // Standard OP_CODES

--- a/tests/script_template.rs
+++ b/tests/script_template.rs
@@ -15,6 +15,31 @@ mod script_template_tests {
     }
 
     #[test]
+    fn op_false_op_zero_and_zero_script_does_match_template() {
+        let script = Script::from_asm_string("0 OP_0 OP_FALSE 00").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("OP_FALSE OP_FALSE 0 00").unwrap();
+        println!("f {:?} {:?}", script, script_template);
+        assert_eq!(script.is_match(&script_template), true);
+    }
+
+    #[test]
+    fn op_true_and_op_one_script_does_match_template() {
+        let script = Script::from_asm_string("OP_1 OP_TRUE").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("OP_1 OP_TRUE").unwrap();
+        assert_eq!(script.is_match(&script_template), true);
+    }
+
+    #[test]
+    fn op_zero_and_zero_zero_script_does_not_match_template() {
+        let script = Script::from_asm_string("0").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("00").unwrap();
+        assert_eq!(script.is_match(&script_template), false);
+        let script = Script::from_asm_string("00").unwrap();
+        let script_template = ScriptTemplate::from_asm_string("0").unwrap();
+        assert_eq!(script.is_match(&script_template), false);
+    }
+
+    #[test]
     fn exact_script_template_matches_script_without_extracting_data() {
         let script =
             Script::from_asm_string("d26f2b12ee0a5923dab7314e533917f2ab5b50da5ce302d3d60941f0ee8000a2 21e8 OP_SIZE OP_4 OP_PICK OP_SHA256 OP_SWAP OP_SPLIT OP_DROP OP_EQUALVERIFY OP_DROP OP_CHECKSIG")


### PR DESCRIPTION
Solving some problems related to script templates using different ways to represent opcodes.
OP_FALSE and OP_TRUE on script and script template.
Make 00 work as a PushData[00] on script and script template. 
Accept -1 as OP_1NEGATE.